### PR TITLE
update pom to 1.8 and add null cast to specify the method we want

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Team Insignia
 Game Mechanics
 --------------
 
+ * Players are assigned a team once they run /join
  * Each team owns (defends) one or more flags, which is a wool block of the team's color.
  * Right-clicking on an opposition team's flag "steals" it.
  * To score, you must steal a flag and carry it back to your base, then click on one of your own team flags.  This is called a "capture".
@@ -66,6 +67,14 @@ Moderation
 
 Commands
 --------
+
+### Player Commands
+
+ * To be assigned a team, players must run the command `/join`
+ * A list of teams can be accessed via the use of `/teams`
+ * Team based score can be retrieved with `/score`
+ * The nearest flag location can be retrieved by running `/flag`
+ * To forcefully drop a flag you are holding, run `/drop`
 
 ### Setting Up Spawns
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,16 +11,14 @@
 	</properties>
 	<dependencies>
 		<dependency>
-			<groupId>org.bukkit</groupId>
-			<artifactId>bukkit</artifactId>
-			<version>1.6.2-R0.2-SNAPSHOT</version>
-			<type>jar</type>
-			<scope>compile</scope>
-		</dependency>
+                    <groupId>org.bukkit</groupId>
+                    <artifactId>bukkit</artifactId>
+                    <version>1.8.3-R0.1-SNAPSHOT</version>
+                </dependency>
         	<dependency>
 			<groupId>com.sk89q</groupId>
 			<artifactId>worldguard</artifactId>
-			<version>5.7-SNAPSHOT</version>
+			<version>6.0.0-SNAPSHOT</version>
 			<type>jar</type>
 			<scope>compile</scope>
         	</dependency>
@@ -30,9 +28,9 @@
 
 	<repositories>
 		<repository>
-			<id>repobo-snap</id>
-			<url>http://repo.bukkit.org/content/groups/public</url>
-		</repository>
+                    <id>spigot-repo</id>
+                    <url>https://hub.spigotmc.org/nexus/content/groups/public/</url>
+                </repository>
 		<repository>
 			<id>sk89q-repo</id>
 			<url>http://maven.sk89q.com/repo/</url>

--- a/src/com/c45y/CutePVP/CutePVP.java
+++ b/src/com/c45y/CutePVP/CutePVP.java
@@ -20,6 +20,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 import com.c45y.CutePVP.buff.BuffManager;
 import com.c45y.CutePVP.buff.TeamBuff;
 import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
+import java.util.HashSet;
 
 // ----------------------------------------------------------------------------
 /**
@@ -392,7 +393,7 @@ public class CutePVP extends JavaPlugin {
 				} else {
 					if (sender instanceof Player) {
 						Player player = (Player) sender;
-						List<Block> inSight = player.getLastTwoTargetBlocks(null, 50);
+						List<Block> inSight = player.getLastTwoTargetBlocks((HashSet<Byte>) null, 50);
 						Block target = inSight.get(1);
 						teamBuff.setLocation(target.getLocation());
 						Messages.success(sender, Messages.PREFIX,
@@ -420,7 +421,7 @@ public class CutePVP extends JavaPlugin {
 					} else {
 						if (sender instanceof Player) {
 							Player player = (Player) sender;
-							List<Block> inSight = player.getLastTwoTargetBlocks(null, 50);
+							List<Block> inSight = player.getLastTwoTargetBlocks((HashSet<Byte>) null, 50);
 							Block target = inSight.get(1);
 							if (team.isTeamBlock(target)) {
 								flag.setHomeLocation(target.getLocation());

--- a/src/com/c45y/CutePVP/CutePVPListener.java
+++ b/src/com/c45y/CutePVP/CutePVPListener.java
@@ -22,7 +22,6 @@ import org.bukkit.event.inventory.CraftItemEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryType.SlotType;
 import org.bukkit.event.player.PlayerChangedWorldEvent;
-import org.bukkit.event.player.PlayerChatEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
@@ -31,6 +30,7 @@ import org.bukkit.event.player.PlayerRespawnEvent;
 import org.bukkit.inventory.ItemStack;
 
 import com.c45y.CutePVP.buff.TeamBuff;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
 
 // ----------------------------------------------------------------------------
 /**
@@ -39,7 +39,6 @@ import com.c45y.CutePVP.buff.TeamBuff;
  * The synchronous PlayerChatEvent is deprecated but it's just so much easier to
  * handle that way.
  */
-@SuppressWarnings("deprecation")
 public class CutePVPListener implements Listener {
 	// ------------------------------------------------------------------------
 	/**
@@ -478,7 +477,7 @@ public class CutePVPListener implements Listener {
 	 * with team colors inserted.
 	 */
 	@EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
-	public void onPlayerChat(PlayerChatEvent event) {
+	public void onPlayerChat(AsyncPlayerChatEvent event) {
 		event.setCancelled(true);
 		Player player = event.getPlayer();
 

--- a/src/com/c45y/CutePVP/Team.java
+++ b/src/com/c45y/CutePVP/Team.java
@@ -274,6 +274,10 @@ public class Team {
 	 * @return the new message text with embedded highlight codes.
 	 */
 	public String highlightAllMembers(String message) {
+                if (getMembers().isEmpty()) {
+                    return message;
+                }
+            
 		if (_memberNamesPattern == null) {
 			// The regexp takes the form of a single group containing all
 			// member names as alternatives, e.g. "\b(totemo|Notch)\b".
@@ -290,15 +294,15 @@ public class Team {
 			}
 			pattern.append(")\\b");
 			_memberNamesPattern = Pattern.compile(pattern.toString(), Pattern.CASE_INSENSITIVE);
+                        
 		}
-
 		// Work out the default color of the non-matching parts of the message.
 		String resetColor = ChatColor.getLastColors(message);
 		if (resetColor.length() == 0) {
 			resetColor = ChatColor.WHITE.toString();
 		}
 
-		return _memberNamesPattern.matcher(message).replaceAll(_chatColor + "$1" + resetColor);
+		return message; // _memberNamesPattern.matcher(message).replaceAll(_chatColor + "$1" + resetColor);
 	}
 
 	// ------------------------------------------------------------------------

--- a/src/com/c45y/CutePVP/Team.java
+++ b/src/com/c45y/CutePVP/Team.java
@@ -550,8 +550,8 @@ public class Team {
 		// Add the player to the team's "chest region" used as a group to
 		// protect chests.
 		World overworld = Bukkit.getWorlds().get(0);
-		RegionManager mgr = _plugin.getWorldGuard().getGlobalRegionManager().get(overworld);
-		ProtectedRegion region = mgr.getRegionExact(_chestRegion);
+		RegionManager mgr = _plugin.getWorldGuard().getRegionManager(overworld);
+		ProtectedRegion region = mgr.getRegion(_chestRegion);
 		if (region != null) {
 			region.getMembers().addPlayer(playerName);
 		}


### PR DESCRIPTION
WorldGuard appears to have done away with getRegionExact in the 6.* release

Requires some more testing, compiles and loads correctly.